### PR TITLE
Remove section title string as workaround of Consent bug

### DIFF
--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -207,12 +207,10 @@ static NSString *const _FamilyNameIdentifier = @"family";
     givenNameFormItem.optional = NO;
     familyNameFormItem.optional = NO;
     
-    ORKFormItem *sectionTitleFormItem = [[ORKFormItem alloc] initWithSectionTitle:ORKLocalizedString(@"CONSENT_NAME_SECTION_TITLE", nil)];
-    
-    NSArray *formItems = @[sectionTitleFormItem, givenNameFormItem, familyNameFormItem];
+    NSArray *formItems = @[givenNameFormItem, familyNameFormItem];
     if (ORKCurrentLocalePresentsFamilyNameFirst())
     {
-        formItems = @[sectionTitleFormItem, familyNameFormItem, givenNameFormItem];
+        formItems = @[familyNameFormItem, givenNameFormItem];
     }
     
     [formStep setFormItems:formItems];

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -214,6 +214,7 @@ static NSString *const _FamilyNameIdentifier = @"family";
     }
     
     [formStep setFormItems:formItems];
+    formStep.useCardView = NO;
     
     formStep.optional = NO;
     

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -207,14 +207,15 @@ static NSString *const _FamilyNameIdentifier = @"family";
     givenNameFormItem.optional = NO;
     familyNameFormItem.optional = NO;
     
-    NSArray *formItems = @[givenNameFormItem, familyNameFormItem];
+    ORKFormItem *sectionTitleFormItem = [[ORKFormItem alloc] initWithSectionTitle:@""];
+    
+    NSArray *formItems = @[sectionTitleFormItem, givenNameFormItem, familyNameFormItem];
     if (ORKCurrentLocalePresentsFamilyNameFirst())
     {
-        formItems = @[familyNameFormItem, givenNameFormItem];
+        formItems = @[sectionTitleFormItem, familyNameFormItem, givenNameFormItem];
     }
     
     [formStep setFormItems:formItems];
-    formStep.useCardView = NO;
     
     formStep.optional = NO;
     

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -218,7 +218,6 @@ static NSString *const _FamilyNameIdentifier = @"family";
     [formStep setFormItems:formItems];
     
     formStep.optional = NO;
-    formStep.useCardView = NO;
     
     ORKTextQuestionResult *givenNameDefault = [[ORKTextQuestionResult alloc] initWithIdentifier:_GivenNameIdentifier];
     givenNameDefault.textAnswer = _signatureFirst;

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -218,6 +218,7 @@ static NSString *const _FamilyNameIdentifier = @"family";
     [formStep setFormItems:formItems];
     
     formStep.optional = NO;
+    formStep.useCardView = NO;
     
     ORKTextQuestionResult *givenNameDefault = [[ORKTextQuestionResult alloc] initWithIdentifier:_GivenNameIdentifier];
     givenNameDefault.textAnswer = _signatureFirst;


### PR DESCRIPTION
Tried removing the `sectionTitleFormItem` from `formItems` and it turned out that ResearchKit `ORKFormStepViewController` is always expecting a title formItem. 

As a workaround to this issue, I'm just removing the localisable key and replace it with empty string.